### PR TITLE
docs(config/eslint):update readme json code block

### DIFF
--- a/packages/config/eslint/README.md
+++ b/packages/config/eslint/README.md
@@ -53,7 +53,7 @@ module.exports = config;
 
 Once the above-defined `./.eslintrc.js` file has been generated, the following scripts can be amended to the localized `./package.json` file.
 
-```json
+```json5
 {
   /* ... */
   "scripts": {


### PR DESCRIPTION
# Description

The scope of the changes in this pull request are to update the documentation for `@alboe/eslint-config` within its `README.md` file. The code block format was set to `json`, when it should have been set to `jsonc` or `json5`. This code block has been updated to `json5`.

# Links

[GitHub Project Case](https://github.com/orgs/alboe-development/projects/4/views/3?pane=issue&itemId=31923924)
