### PR TITLE
test(design/components): add component tests

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Alboe Development
+Copyright (c) 2025 Alboe Development
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/modules/design/components/jest.config.js
+++ b/modules/design/components/jest.config.js
@@ -1,3 +1,0 @@
-const { common } = require('@alboe/jest-config');
-
-module.exports = common;

--- a/modules/design/components/package.json
+++ b/modules/design/components/package.json
@@ -24,15 +24,15 @@
     "build:module": "tsc --outDir ./dist/module",
     "build:types": "tsc --declaration --emitDeclarationOnly --declarationDir ./dist/types",
     "clean": "rimraf ./dist",
-    "test": "yarn test:module && yarn test:coverage",
-    "test:coverage": "yarn test:module --coverage --reporters=\"jest-silent-reporter\"",
-    "test:module": "jest"
+    "test": "yarn test:module",
+    "test:module": "node --test --no-warnings --experimental-test-coverage --test-coverage-include=\"dist/module/**/*.js\" --test-coverage-lines=100"
   },
   "dependencies": {
     "lit": "^3"
   },
   "devDependencies": {
     "@alboe/api-extractor-config": "workspace:*",
+    "@alboe/design-components": "workspace:*",
     "@alboe/eslint-config": "workspace:*",
     "@alboe/jest-config": "workspace:*",
     "@alboe/typescript-config": "workspace:*",
@@ -40,8 +40,6 @@
     "@microsoft/api-documenter": "^7",
     "@microsoft/api-extractor": "^7.49.2",
     "eslint": "^9",
-    "jest": "^29",
-    "jest-silent-reporter": "^0",
     "rimraf": "^6",
     "typescript": "<5.6.0"
   }

--- a/modules/design/components/src/models/component/class.fixture.js
+++ b/modules/design/components/src/models/component/class.fixture.js
@@ -1,0 +1,11 @@
+const { Component } = require('@alboe/design-components');
+
+class FixtureComponent extends Component {
+  get namespace() {
+    return 'adc-fixture-component';
+  }
+
+  static styles = [];
+}
+
+module.exports = { Component: FixtureComponent };

--- a/modules/design/components/src/models/component/class.test.js
+++ b/modules/design/components/src/models/component/class.test.js
@@ -1,0 +1,123 @@
+const assert = require('node:assert');
+const { afterEach, beforeEach, describe, mock, it, verifyThat } = require('node:test');
+const { Component } = require('./class.fixture');
+
+describe('Component', () => {
+  describe('static', () => {
+    describe('styles', () => {
+      it('should be defined as an empty array', () => {
+        const { styles } = Component;
+
+        assert(Array.isArray(styles));
+        assert.equal(styles.length, 0);
+      });
+    });
+
+    describe('register()', () => {
+      let spies;
+
+      beforeEach(() => {
+        globalThis.customElements = {
+          define: mock.fn(),
+          get: mock.fn(),
+        };
+
+        spies = {
+          Component: {
+            prototype: {
+              namespace: mock.getter(Component.prototype, 'namespace'),
+            }
+          },
+        };
+      });
+
+      afterEach(() => {
+        delete globalThis.customElements;
+      });
+
+      it('should register the provided component', () => {
+        const options = { component: {} };
+        
+        Component.register(options);
+
+        const { calls } = globalThis.customElements.define.mock;
+
+        assert.equal(calls.length, 1);
+        assert.equal(calls[0].arguments[1], options.component);
+      });
+
+      it('should register itself when no component is provided', () => {
+        const options = { component: undefined };
+        
+        Component.register(options);
+
+        const { calls } = globalThis.customElements.define.mock;
+
+        assert.equal(calls.length, 1);
+        assert.equal(calls[0].arguments[1], Component);
+      });
+
+      it('should use the provided namespace when registering', () => {
+        const options = { namespace: 'example-namespace' };
+        
+        Component.register(options);
+
+        const { calls } = globalThis.customElements.define.mock;
+
+        assert.equal(calls.length, 1);
+        assert.equal(calls[0].arguments[0], options.namespace);
+      });
+
+      it('should use itself when registering when no namespace is provided', () => {
+        const options = { namespace: undefined };
+        
+        Component.register(options);
+
+        const { calls } = globalThis.customElements.define.mock;
+
+        assert.equal(calls.length, 1);
+        assert.equal(calls[0].arguments[0], Component.prototype.namespace);
+      });
+
+      it('should use the provided registry when registering', () => {
+        const options = {
+          registry: {
+            define: mock.fn(),
+            get: () => undefined,
+          }
+        };
+        
+        Component.register(options);
+
+        const { calls } = options.registry.define.mock;
+
+        assert.equal(calls.length, 1);
+      });
+
+      it('should use the global registery when no registry is provided', () => {
+        const options = { registry: undefined };
+        
+        Component.register(options);
+
+        const { calls } = globalThis.customElements.define.mock;
+
+        assert.equal(calls.length, 1);
+      });
+
+      it('should return without registering the component if it is already registered', () => {
+        const options = {
+          registry: {
+            define: mock.fn(),
+            get: () => ({}),
+          }
+        };
+        
+        Component.register(options);
+
+        const { calls } = globalThis.customElements.define.mock;
+
+        assert.equal(calls.length, 0);
+      });
+    });
+  });
+});

--- a/modules/design/components/src/models/component/class.ts
+++ b/modules/design/components/src/models/component/class.ts
@@ -18,6 +18,8 @@ abstract class Component extends LitElement {
    * The namespace to use when registering this component to the custom
    */
   public abstract get namespace(): string
+  
+  public static override styles = [];
 
   /**
    * Register a component.

--- a/modules/design/components/src/models/component/types.ts
+++ b/modules/design/components/src/models/component/types.ts
@@ -7,21 +7,21 @@ export interface ComponentRegisterOptions {
   /**
    * The Component to use when registering.
    * 
-   * @default this
+   * @defaultValue this
    */
   component?: CustomElementConstructor;
 
   /**
    * The namespace to use when registering the Component.
    * 
-   * @default this.prototype.namespace
+   * @defaultValue this.prototype.namespace
    */
   namespace?: string;
 
   /**
    * The registry to use when registering the Component.
    * 
-   * @default globalThis.customElements
+   * @defaultValue globalThis.customElements
    */
   registry?: CustomElementRegistry;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11,11 +11,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@alboe/design-components@workspace:modules/design/components":
+"@alboe/design-components@workspace:*, @alboe/design-components@workspace:modules/design/components":
   version: 0.0.0-use.local
   resolution: "@alboe/design-components@workspace:modules/design/components"
   dependencies:
     "@alboe/api-extractor-config": "workspace:*"
+    "@alboe/design-components": "workspace:*"
     "@alboe/eslint-config": "workspace:*"
     "@alboe/jest-config": "workspace:*"
     "@alboe/typescript-config": "workspace:*"
@@ -23,8 +24,6 @@ __metadata:
     "@microsoft/api-documenter": "npm:^7"
     "@microsoft/api-extractor": "npm:^7.49.2"
     eslint: "npm:^9"
-    jest: "npm:^29"
-    jest-silent-reporter: "npm:^0"
     lit: "npm:^3"
     rimraf: "npm:^6"
     typescript: "npm:<5.6.0"


### PR DESCRIPTION
# Description

The scope of the changes in this change request is to add testing to the `@alboe/design-components`: `Component` export.

# Links

- #29 