### PR TITLE
feat(design/components): create layout header

### DIFF
--- a/modules/design/components/package.json
+++ b/modules/design/components/package.json
@@ -21,9 +21,7 @@
     "build:docs:api:markdown": "api-documenter markdown --input-folder ./dist/docs/api/metadata --output-folder ./dist/docs/api/markdown",
     "build:docs:api:metadata": "api-extractor run --local --verbose",
     "build:module": "tsc --outDir ./dist/module",
-    "build:types": "tsc --declaration --emitDeclarationOnly --declarationDir ./dist/types",
-    "test": "pnpm test:module",
-    "test:module": "node --test --no-warnings --experimental-test-coverage --test-reporter=spec --test-coverage-include=\"dist/module/**/*.js\" --test-coverage-lines=100"
+    "build:types": "tsc --declaration --emitDeclarationOnly --declarationDir ./dist/types"
   },
   "dependencies": {
     "lit": "^3"

--- a/modules/design/components/src/index.ts
+++ b/modules/design/components/src/index.ts
@@ -3,12 +3,7 @@
  * 
  * @packageDocumentation
  */
-export {
-  Component,
-  type ComponentRegisterOptions,
-} from './models';
 
-export {
-  TokenProvider,
-  type TokenProviderProperties,
-} from './providers';
+export * as Layout from './layout';
+export * as Models from './models';
+export * as Providers from './providers';

--- a/modules/design/components/src/layout/header/component.ts
+++ b/modules/design/components/src/layout/header/component.ts
@@ -1,0 +1,36 @@
+import * as Models from '../../models';
+import { CONSTANTS } from './constants';
+import { styles } from './styles';
+import { tokens } from './tokens';
+import type { Properties, Size } from './types';
+
+/**
+ * The Layout Header Component.
+ *
+ * @remarks
+ * This component acts as a header within a page's layout.
+ *
+ * @public
+ */
+class Component extends Models.Component.Component implements Properties {
+  public size?: Size;
+
+  public constructor() {
+    super();
+
+    this.size = CONSTANTS.DEFAULTS.SIZE;
+  }
+
+  public get namespace() {
+    return CONSTANTS.NAMESPACE;
+  }
+
+  public static override properties = {
+    branded: { reflect: true, type: Boolean },
+    size: { reflect: true, type: String },
+  };
+
+  public static override styles = [...super.styles, tokens, styles];
+}
+
+export { Component };

--- a/modules/design/components/src/layout/header/constants.ts
+++ b/modules/design/components/src/layout/header/constants.ts
@@ -1,0 +1,35 @@
+const NAMESPACE = 'adc-layout-header';
+
+const SIZES = {
+  LARGE: 'large',
+  MEDIUM: 'medium',
+  SMALL: 'small',
+} as const;
+
+const DEFAULTS = {
+  SIZE: SIZES.MEDIUM,
+} as const;
+
+/**
+ * Constants associated with this component.
+ * 
+ * @public
+ */
+const CONSTANTS = {
+  /**
+   * The default values for the properties of this component.
+   */
+  DEFAULTS,
+
+  /**
+   * The namespace associated with this component.
+   */
+  NAMESPACE,
+
+  /**
+   * Possible sizes to be assigned to this component.
+   */
+  SIZES,
+} as const;
+
+export { CONSTANTS };

--- a/modules/design/components/src/layout/header/index.ts
+++ b/modules/design/components/src/layout/header/index.ts
@@ -1,4 +1,5 @@
 export * from './component';
 export * from './constants';
 export * from './styles';
+export * from './tokens';
 export * from './types';

--- a/modules/design/components/src/layout/header/styles.ts
+++ b/modules/design/components/src/layout/header/styles.ts
@@ -1,0 +1,38 @@
+import { css } from 'lit';
+
+/**
+ * Styles associated with this component.
+ * 
+ * @public
+ */
+const styles = css`
+:host {
+  align-items: center;
+  background-color: var(--adc-layout-header-color-background);
+  color: var(--adc-layout-header-color-text);
+  display: flex;
+  flex-grow: 0;
+  flex-shrink: 0;
+  height: var(--adc-layout-header-dimension-height);
+  width: 100%;
+}
+
+:host {
+  --adc-layout-header-color-text: var(--adc-layout-header-color-text-normal);
+  --adc-layout-header-color-background: var(--adc-layout-header-color-background-normal);
+}
+
+:host([size="large"]) {
+  --adc-layout-header-dimension-height: var(--adc-layout-header-dimension-height-large);
+}
+
+:host([size="medium"]) {
+  --adc-layout-header-dimension-height: var(--adc-layout-header-dimension-height-medium);
+}
+
+:host([size="small"]) {
+  --adc-layout-header-dimension-height: var(--adc-layout-header-dimension-height-small)
+}
+`;
+
+export { styles };

--- a/modules/design/components/src/layout/header/tokens.ts
+++ b/modules/design/components/src/layout/header/tokens.ts
@@ -1,0 +1,18 @@
+import { css } from 'lit';
+
+/**
+ * Tokens associated with this component
+ * 
+ * @public
+ */
+const tokens = css`
+:host {
+  --adc-layout-header-color-background-normal: var(--adt-color-background-layout-normal);
+  --adc-layout-header-color-text-normal: var(--adt-color-text-layout-strongest);
+  --adc-layout-header-dimension-height-large: var(--adt-dimension-size-layout-medium);
+  --adc-layout-header-dimension-height-medium: var(--adt-dimension-size-layout-small);
+  --adc-layout-header-dimension-height-small: var(--adt-dimension-size-layout-smaller);
+}
+`;
+
+export { tokens };

--- a/modules/design/components/src/layout/header/types.ts
+++ b/modules/design/components/src/layout/header/types.ts
@@ -1,0 +1,20 @@
+import type { CONSTANTS } from './constants';
+
+/**
+ * Size of this component.
+ * 
+ * @public
+ */
+export type Size = typeof CONSTANTS.SIZES[keyof typeof CONSTANTS.SIZES];
+
+/**
+ * Properties to be utilized within this component.
+ * 
+ * @public
+ */
+export interface Properties {
+  /**
+   * Size of this component.
+   */
+  size?: Size;
+}

--- a/modules/design/components/src/layout/index.ts
+++ b/modules/design/components/src/layout/index.ts
@@ -1,0 +1,1 @@
+export * as Header from './header';

--- a/modules/design/components/src/models/component/component.ts
+++ b/modules/design/components/src/models/component/component.ts
@@ -1,5 +1,5 @@
-import { type CSSResult, LitElement } from 'lit';
-import type { ComponentRegisterOptions } from './types';
+import { type CSSResult, html, LitElement } from 'lit';
+import type { RegisterOptions } from './types';
 
 /**
  * The core Component for this project.
@@ -27,7 +27,7 @@ abstract class Component extends LitElement {
    * @param options - Options to use.
    * @returns - Void.
    */
-  public static register(options: ComponentRegisterOptions = {}): void {
+  public static register(options: RegisterOptions = {}): void {
     const {
       component = this,
       namespace = this.prototype.namespace,
@@ -39,6 +39,10 @@ abstract class Component extends LitElement {
     }
 
     registry.define(namespace, component as unknown as CustomElementConstructor);
+  }
+
+  public override render() {
+    return html`<slot></slot>`;
   }
 }
 

--- a/modules/design/components/src/models/component/index.ts
+++ b/modules/design/components/src/models/component/index.ts
@@ -1,2 +1,2 @@
-export { Component } from './component';
-export type { ComponentRegisterOptions } from './types';
+export * from './component';
+export * from './types';

--- a/modules/design/components/src/models/component/types.ts
+++ b/modules/design/components/src/models/component/types.ts
@@ -3,7 +3,7 @@
  * 
  * @public
  */
-export interface ComponentRegisterOptions {
+export interface RegisterOptions {
   /**
    * The Component to use when registering.
    * 

--- a/modules/design/components/src/models/index.ts
+++ b/modules/design/components/src/models/index.ts
@@ -1,4 +1,1 @@
-export {
-  Component,
-  type ComponentRegisterOptions,
-} from './component';
+export * as Component from './component';

--- a/modules/design/components/src/providers/index.ts
+++ b/modules/design/components/src/providers/index.ts
@@ -1,4 +1,1 @@
-export {
-  TokenProvider,
-  type TokenProviderProperties,
-} from './token';
+export * as Token from './token';

--- a/modules/design/components/src/providers/token/component.ts
+++ b/modules/design/components/src/providers/token/component.ts
@@ -1,18 +1,18 @@
-import { Component } from '../../models';
+import * as Models from '../../models';
 import { CONSTANTS } from './constants';
 import { styles } from './styles';
-import type { TokenProviderProperties } from './types';
+import type { Properties } from './types';
 
 /**
- * The Token Provider Component.
+ * The Provider Token Component.
  * 
  * @remarks
- * this component acts as a simple translation layer from DOM-specified
+ * This component acts as a simple translation layer from DOM-specified
  * attributes to all nested components.
  * 
  * @public
  */
-class TokenProvider extends Component implements TokenProviderProperties {
+class Component extends Models.Component.Component implements Properties {
   public dimension?: string;
 
   public duration?: string;
@@ -30,13 +30,6 @@ class TokenProvider extends Component implements TokenProviderProperties {
   };
 
   public static override styles = [...super.styles, styles];
-
-  /**
-   * Constants associated with this TokenProvider Component.
-   */
-  public static get CONSTANTS() {
-    return CONSTANTS;
-  }
 }
 
-export { TokenProvider };
+export { Component };

--- a/modules/design/components/src/providers/token/constants.ts
+++ b/modules/design/components/src/providers/token/constants.ts
@@ -1,6 +1,14 @@
-const NAMESPACE = 'adc-token-provider';
+const NAMESPACE = 'adc-provider-token';
 
+/**
+ * Constants associated with this component.
+ *
+ * @public
+ */
 const CONSTANTS = {
+  /**
+   * The namespace associated with this component.
+   */
   NAMESPACE,
 } as const;
 

--- a/modules/design/components/src/providers/token/styles.ts
+++ b/modules/design/components/src/providers/token/styles.ts
@@ -1,5 +1,10 @@
 import { css } from 'lit';
 
+/**
+ * Styles associated with this component.
+ * 
+ * @public
+ */
 const styles = css`
 :host {
   display: contents;

--- a/modules/design/components/src/providers/token/types.ts
+++ b/modules/design/components/src/providers/token/types.ts
@@ -1,9 +1,9 @@
 /**
- * Properties to be utilized within a `<adc-token-provider />` component.
+ * Properties to be utilized within this component.
  * 
  * @public
  */
-export interface TokenProviderProperties {
+export interface Properties {
   /**
    * Dimension token scope to utilize.
    */

--- a/modules/design/tokens/src/dimension/medium.json
+++ b/modules/design/tokens/src/dimension/medium.json
@@ -1,10 +1,42 @@
 {
   "dimension": {
+    "size": {
+      "layout": {
+        "smallest": {
+          "$type": "dimension",
+          "$value": "32px"
+        },
+        "smaller": {
+          "$type": "dimension",
+          "$value": "48px"
+        },
+        "small": {
+          "$type": "dimension",
+          "$value": "64px"
+        },
+        "medium": {
+          "$type": "dimension",
+          "$value": "96px"
+        },
+        "large": {
+          "$type": "dimension",
+          "$value": "128px"
+        },
+        "larger": {
+          "$type": "dimension",
+          "$value": "196px"
+        },
+        "largest": {
+          "$type": "dimension",
+          "$value": "256px"
+        }
+      }
+    },
     "radius": {
-      "container": {
-        "neutral": {
-          "$value": "16px",
-          "$type": "dimension"
+      "layout": {
+        "medium": {
+          "$type": "dimension",
+          "$value": "16px"
         }
       }
     }

--- a/modules/design/tokens/src/mode/dark.json
+++ b/modules/design/tokens/src/mode/dark.json
@@ -1,7 +1,27 @@
 {
   "color": {
     "background": {
-      "container": {
+      "layout": {
+        "weakest": {
+          "$type": "color",
+          "$value": "#666666ff"
+        },
+        "weaker": {
+          "$type": "color",
+          "$value": "#555555ff"
+        },
+        "weak": {
+          "$type": "color",
+          "$value": "#444444ff"
+        },
+        "normal": {
+          "$type": "color",
+          "$value": "#333333ff"
+        },
+        "strong": {
+          "$type": "color",
+          "$value": "#222222ff"
+        },
         "stronger": {
           "$type": "color",
           "$value": "#111111ff"
@@ -13,7 +33,7 @@
       }
     },
     "text": {
-      "container": {
+      "layout": {
         "strongest": {
           "$type": "color",
           "$value": "#ffffffff"

--- a/modules/design/tokens/src/mode/light.json
+++ b/modules/design/tokens/src/mode/light.json
@@ -1,7 +1,27 @@
 {
   "color": {
     "background": {
-      "container": {
+      "layout": {
+        "weakest": {
+          "$type": "color",
+          "$value": "#999999ff"
+        },
+        "weaker": {
+          "$type": "color",
+          "$value": "#aaaaaaff"
+        },
+        "weak": {
+          "$type": "color",
+          "$value": "#bbbbbbff"
+        },
+        "normal": {
+          "$type": "color",
+          "$value": "#ccccccff"
+        },
+        "strong": {
+          "$type": "color",
+          "$value": "#ddddddff"
+        },
         "stronger": {
           "$type": "color",
           "$value": "#eeeeeeff"
@@ -13,7 +33,7 @@
       }
     },
     "text": {
-      "container": {
+      "layout": {
         "strongest": {
           "$type": "color",
           "$value": "#000000ff"


### PR DESCRIPTION
### Context

<!-- A brief description of the changes made in this pull request. -->

The scope of the changes within this pull request are to add the `<adc-layout-header />` component to the `@alboe/design-components` module.

### Links

<!-- Optional links to relevant resources to this pull request. -->

- Closes #43 
