### PR TITLE
feat(config/eslint): add typescript prefer type rule

### DIFF
--- a/modules/config/eslint/static/typescript.js
+++ b/modules/config/eslint/static/typescript.js
@@ -17,6 +17,11 @@ const generate = () => {
 
   const general = [
     ...typescript.configs.recommended,
+    ...typescript.config({
+      rules: {
+        '@typescript-eslint/consistent-type-imports': 'error',
+      },
+    }),
   ].map((config) => ({
     ...config,
     files: ['**/*.ts'],


### PR DESCRIPTION
### Context

The scope of the changes in this change request are to add additional typescript rules to support explicit type import/export calls.
